### PR TITLE
Add APIs to set controller host, port and address for Agent

### DIFF
--- a/data/org.eclipse.bluechi.Agent.xml
+++ b/data/org.eclipse.bluechi.Agent.xml
@@ -40,6 +40,42 @@
       <arg name="unit" type="s" direction="in" />
     </method>
 
+    <!--
+      SetControllerAddress:
+      @controller_address: SD Bus address used by bluechi agent to connect to bluechi controller
+      @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+      SetControllerAddress() changes SD Bus address used by bluechi agent to connect to bluechi controller.
+    -->
+    <method name="SetControllerAddress">
+      <arg name="controller_address" type="s" direction="in" />
+      <arg name="reconnect" type="b" direction="in" />
+    </method>
+
+    <!--
+      SetControllerHost:
+      @controller_host: The host used by bluechi agent to connect to bluechi controller
+      @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+      SetControllerHost() changes the host used by bluechi agent to connect to bluechi controller.
+    -->
+    <method name="SetControllerHost">
+      <arg name="controller_host" type="s" direction="in" />
+      <arg name="reconnect" type="b" direction="in" />
+    </method>
+
+    <!--
+      SetControllerPort:
+      @controller_port: The port the bluechi controller listens on to establish connections with the bluechi agents
+      @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+      SetControllerPort() changes the port on which bluechi controller is listening for connection request and the bluechi agent is connecting to.
+    -->
+    <method name="SetControllerPort">
+      <arg name="controller_port" type="s" direction="in" />
+      <arg name="reconnect" type="b" direction="in" />
+    </method>
+
 
     <!-- 
       Status:

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -270,6 +270,18 @@ interface.
 
     When a proxy is not needed anymore it is being removed on the node and a `ProxyRemoved` is emitted to notify the controller.
 
+  * `SetControllerAddress(in s controller_address, in b reconnect)`
+
+    Set the new controller address for bluechi-agent node. If reconnect is true, try to reconnect to new bluechi-controller right now.
+
+  * `SetControllerHost(in s controller_host, in b reconnect)`
+
+    Set the new controller host for bluechi-agent node. If reconnect is true, try to reconnect to new bluechi-controller right now.
+
+  * `SetControllerPort(in s controller_port, in b reconnect)`
+
+    Set the new controller port for bluechi-agent node. If reconnect is true, try to reconnect to new bluechi-controller right now.
+
 ### interface org.eclipse.bluechi.Metrics
 
 This interface provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.eclipse.bluechi.Controller` interface and removed by calling `DisableMetrics`.

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1740,6 +1740,105 @@ static int agent_method_remove_proxy(sd_bus_message *m, UNUSED void *userdata, U
 
 
 /*************************************************************************
+ **** org.eclipse.bluechi.Agent.SetControllerAddress **
+ *************************************************************************/
+
+static int agent_method_set_controller_address(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Agent *agent = userdata;
+        const char *controller_address = NULL;
+        int reconnect = 0;
+
+        int r = sd_bus_message_read(m, "sb", &controller_address, &reconnect);
+        if (r < 0) {
+                bc_log_errorf("Failed to read ControllerAddress parameter: %s", strerror(-r));
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_FAILED,
+                                "Failed to read ControllerAddress parameter: %s",
+                                strerror(-r));
+        }
+
+        if (!agent_set_controller_address(agent, controller_address)) {
+                bc_log_error("Failed to set CONTROLLER ADDRESS");
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Failed to set CONTROLLER ADDRESS");
+        }
+        bc_log_infof("CONTROLLER ADDRESS changed to %s", controller_address);
+
+        if (reconnect) {
+                agent_disconnected(NULL, userdata, NULL);
+        }
+
+        return sd_bus_reply_method_return(m, "");
+}
+
+
+/*************************************************************************
+ **** org.eclipse.bluechi.Agent.SetControllerHost *****
+ *************************************************************************/
+
+static int agent_method_set_controller_host(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Agent *agent = userdata;
+        const char *controller_host = NULL;
+        int reconnect = 0;
+
+        int r = sd_bus_message_read(m, "sb", &controller_host, &reconnect);
+        if (r < 0) {
+                bc_log_errorf("Failed to read ControllerHost parameter: %s", strerror(-r));
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_FAILED,
+                                "Failed to read ControllerHost parameter: %s",
+                                strerror(-r));
+        }
+
+        if (!agent_set_host(agent, controller_host)) {
+                bc_log_error("Failed to set CONTROLLER HOST");
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Failed to set CONTROLLER HOST");
+        }
+        bc_log_infof("CONTROLLER HOST changed to %s", controller_host);
+
+        if (reconnect) {
+                agent_disconnected(NULL, userdata, NULL);
+        }
+
+        return sd_bus_reply_method_return(m, "");
+}
+
+
+/*************************************************************************
+ **** org.eclipse.bluechi.Agent.SetControllerPort *****
+ *************************************************************************/
+
+static int agent_method_set_controller_port(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Agent *agent = userdata;
+        const char *controller_port = NULL;
+        int reconnect = 0;
+
+        int r = sd_bus_message_read(m, "sb", &controller_port, &reconnect);
+        if (r < 0) {
+                bc_log_errorf("Failed to read ControllerPort parameter: %s", strerror(-r));
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_FAILED,
+                                "Failed to read ControllerPort parameter: %s",
+                                strerror(-r));
+        }
+
+        if (!agent_set_port(agent, controller_port)) {
+                bc_log_error("Failed to set CONTROLLER PORT");
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Failed to set CONTROLLER PORT");
+        }
+        bc_log_infof("CONTROLLER PORT changed to %s", controller_port);
+
+        if (reconnect) {
+                agent_disconnected(NULL, userdata, NULL);
+        }
+
+        return sd_bus_reply_method_return(m, "");
+}
+
+
+/*************************************************************************
  **** org.eclipse.bluechi.Agent.Status ****************
  *************************************************************************/
 
@@ -1809,6 +1908,9 @@ static const sd_bus_vtable agent_vtable[] = {
         SD_BUS_VTABLE_START(0),
         SD_BUS_METHOD("CreateProxy", "sss", "", agent_method_create_proxy, 0),
         SD_BUS_METHOD("RemoveProxy", "sss", "", agent_method_remove_proxy, 0),
+        SD_BUS_METHOD("SetControllerAddress", "sb", "", agent_method_set_controller_address, 0),
+        SD_BUS_METHOD("SetControllerHost", "sb", "", agent_method_set_controller_host, 0),
+        SD_BUS_METHOD("SetControllerPort", "sb", "", agent_method_set_controller_port, 0),
 
         SD_BUS_PROPERTY("Status", "s", agent_property_get_status, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_PROPERTY("LogLevel", "s", agent_property_get_log_level, 0, SD_BUS_VTABLE_PROPERTY_EXPLICIT),

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -133,6 +133,45 @@ class Agent(ApiBase):
             unit,
         )
 
+    def set_controller_address(self, controller_address: str, reconnect: bool) -> None:
+        """
+          SetControllerAddress:
+        @controller_address: SD Bus address used by bluechi agent to connect to bluechi controller
+        @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+        SetControllerAddress() changes SD Bus address used by bluechi agent to connect to bluechi controller.
+        """
+        self.get_proxy().SetControllerAddress(
+            controller_address,
+            reconnect,
+        )
+
+    def set_controller_host(self, controller_host: str, reconnect: bool) -> None:
+        """
+          SetControllerHost:
+        @controller_host: The host used by bluechi agent to connect to bluechi controller
+        @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+        SetControllerHost() changes the host used by bluechi agent to connect to bluechi controller.
+        """
+        self.get_proxy().SetControllerHost(
+            controller_host,
+            reconnect,
+        )
+
+    def set_controller_port(self, controller_port: str, reconnect: bool) -> None:
+        """
+          SetControllerPort:
+        @controller_port: The port the bluechi controller listens on to establish connections with the bluechi agents
+        @reconnect: Specify if bluechi agent reconnects to new bluechi controller right now
+
+        SetControllerPort() changes the port on which bluechi controller is listening for connection request and the bluechi agent is connecting to.
+        """
+        self.get_proxy().SetControllerPort(
+            controller_port,
+            reconnect,
+        )
+
     @property
     def disconnect_timestamp(self) -> UInt64:
         """


### PR DESCRIPTION
This adds public APIs to set controller host, port and address to the bluechi-agent.

Because it's possible to change the host, port and address used by agent to connect controller on the fly using these APIs, the agent can reconnect to controller of new node without restarting when the node of working bluechi controller is changed.

If reconnect is true, try to reconnect to new bluechi-controller right now.