### PR TITLE
Add an API method to switch controller for agent

### DIFF
--- a/data/org.eclipse.bluechi.Agent.xml
+++ b/data/org.eclipse.bluechi.Agent.xml
@@ -40,6 +40,17 @@
       <arg name="unit" type="s" direction="in" />
     </method>
 
+    <!--
+      SwitchController:
+      @dbus_address: SD Bus address used to connect to the BlueChi controller
+
+      SwitchController() changes SD Bus address used to connect to the BlueChi controller and
+      triggers a reconnect to the BlueChi controller with the new address.
+    -->
+    <method name="SwitchController">
+      <arg name="dbus_address" type="s" direction="in" />
+    </method>
+
 
     <!-- 
       Status:
@@ -79,6 +90,16 @@
     -->
     <property name="DisconnectTimestamp" type="t" access="read">
       <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false" />
+    </property>
+
+    <!--
+      ControllerAddress:
+
+      SD Bus address used to connect to the BlueChi controller.
+      On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+    -->
+    <property name="ControllerAddress" type="s" access="read">
+      <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="true" />
     </property>
 
   </interface>

--- a/doc/docs/api/description.md
+++ b/doc/docs/api/description.md
@@ -276,6 +276,10 @@ interface.
 
     When a proxy is not needed anymore it is being removed on the node and a `ProxyRemoved` is emitted to notify the controller.
 
+  * `SwitchController(in s controller_address)`
+
+    Set the new controller address for bluechi-agent node and trigger a reconnect to the controller with the new address.
+
 ### interface org.eclipse.bluechi.Metrics
 
 This interface provides signals for collecting metrics. It is created by calling `EnableMetrics` on the `org.eclipse.bluechi.Controller` interface and removed by calling `DisableMetrics`.

--- a/src/agent/agent.c
+++ b/src/agent/agent.c
@@ -1809,6 +1809,43 @@ static int agent_method_remove_proxy(sd_bus_message *m, UNUSED void *userdata, U
 
 
 /*************************************************************************
+ **** org.eclipse.bluechi.Agent.SwitchController ******
+ *************************************************************************/
+
+static int agent_method_switch_controller(sd_bus_message *m, void *userdata, UNUSED sd_bus_error *ret_error) {
+        Agent *agent = userdata;
+        const char *dbus_address = NULL;
+
+        int r = sd_bus_message_read(m, "s", &dbus_address);
+        if (r < 0) {
+                bc_log_errorf("Failed to read DbusAddress parameter: %s", strerror(-r));
+                return sd_bus_reply_method_errorf(
+                                m,
+                                SD_BUS_ERROR_FAILED,
+                                "Failed to read DbusAddress parameter: %s",
+                                strerror(-r));
+        }
+
+        if (!agent_set_controller_address(agent, dbus_address)) {
+                bc_log_error("Failed to set CONTROLLER ADDRESS");
+                return sd_bus_reply_method_errorf(m, SD_BUS_ERROR_FAILED, "Failed to set CONTROLLER ADDRESS");
+        }
+
+        r = sd_bus_emit_properties_changed(
+                        agent->api_bus, BC_AGENT_OBJECT_PATH, AGENT_INTERFACE, "ControllerAddress", NULL);
+        if (r < 0) {
+                bc_log_errorf("Failed to emit controller address property changed: %s", strerror(-r));
+        }
+
+        bc_log_infof("CONTROLLER ADDRESS changed to %s", dbus_address);
+
+        agent_disconnected(NULL, userdata, NULL);
+
+        return sd_bus_reply_method_return(m, "");
+}
+
+
+/*************************************************************************
  **** org.eclipse.bluechi.Agent.Status ****************
  *************************************************************************/
 
@@ -1873,12 +1910,30 @@ static int agent_property_get_log_target(
         return sd_bus_message_append(reply, "s", log_target_to_str(bc_log_get_log_fn()));
 }
 
+/*************************************************************************
+ **** org.eclipse.bluechi.Agent.ControllerAddress *****
+ *************************************************************************/
+static int agent_property_get_controller_address(
+                UNUSED sd_bus *bus,
+                UNUSED const char *path,
+                UNUSED const char *interface,
+                UNUSED const char *property,
+                sd_bus_message *reply,
+                void *userdata,
+                UNUSED sd_bus_error *ret_error) {
+        Agent *agent = userdata;
+
+        return sd_bus_message_append(reply, "s", agent->controller_address);
+}
+
 
 static const sd_bus_vtable agent_vtable[] = {
         SD_BUS_VTABLE_START(0),
         SD_BUS_METHOD("CreateProxy", "sss", "", agent_method_create_proxy, 0),
         SD_BUS_METHOD("RemoveProxy", "sss", "", agent_method_remove_proxy, 0),
         SD_BUS_METHOD("JobCancel", "u", "", agent_method_job_cancel, 0),
+        SD_BUS_METHOD("SwitchController", "s", "", agent_method_switch_controller, 0),
+
         SD_BUS_PROPERTY("Status", "s", agent_property_get_status, 0, SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_PROPERTY("LogLevel", "s", agent_property_get_log_level, 0, SD_BUS_VTABLE_PROPERTY_EXPLICIT),
         SD_BUS_PROPERTY("LogTarget", "s", agent_property_get_log_target, 0, SD_BUS_VTABLE_PROPERTY_CONST),
@@ -1887,6 +1942,11 @@ static const sd_bus_vtable agent_vtable[] = {
                         agent_property_get_disconnect_timestamp,
                         0,
                         SD_BUS_VTABLE_PROPERTY_EXPLICIT),
+        SD_BUS_PROPERTY("ControllerAddress",
+                        "s",
+                        agent_property_get_controller_address,
+                        0,
+                        SD_BUS_VTABLE_PROPERTY_EMITS_CHANGE),
         SD_BUS_VTABLE_END
 };
 

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -50,6 +50,7 @@ DBUS_PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 
 
 class ApiBase:
+
     def __init__(
         self,
         interface: str,
@@ -822,9 +823,10 @@ class Node(ApiBase):
             runtime,
         )
 
-    def enable_unit_files(
-        self, files: List[str], runtime: bool, force: bool
-    ) -> Tuple[bool, List[Tuple[str, str, str]],]:
+    def enable_unit_files(self, files: List[str], runtime: bool, force: bool) -> Tuple[
+        bool,
+        List[Tuple[str, str, str]],
+    ]:
         """
           EnableUnitFiles:
         @files: A list of units to enable

--- a/src/bindings/python/bluechi/api.py
+++ b/src/bindings/python/bluechi/api.py
@@ -132,6 +132,47 @@ class Agent(ApiBase):
             unit,
         )
 
+    def switch_controller(self, dbus_address: str) -> None:
+        """
+          SwitchController:
+        @dbus_address: SD Bus address used to connect to the BlueChi controller
+
+        SwitchController() changes SD Bus address used to connect to the BlueChi controller and
+        triggers a reconnect to the BlueChi controller with the new address.
+        """
+        self.get_proxy().SwitchController(
+            dbus_address,
+        )
+
+    @property
+    def controller_address(self) -> str:
+        """
+          ControllerAddress:
+
+        SD Bus address used to connect to the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+        return self.get_proxy().ControllerAddress
+
+    def on_controller_address_changed(self, callback: Callable[[Variant], None]):
+        """
+          ControllerAddress:
+
+        SD Bus address used to connect to the BlueChi controller.
+        On any change, a signal is emitted on the org.freedesktop.DBus.Properties interface.
+        """
+
+        def on_properties_changed(
+            interface: str,
+            changed_props: Dict[str, Variant],
+            invalidated_props: Dict[str, Variant],
+        ) -> None:
+            value = changed_props.get("ControllerAddress")
+            if value is not None:
+                callback(value)
+
+        self.get_properties_proxy().PropertiesChanged.connect(on_properties_changed)
+
     @property
     def disconnect_timestamp(self) -> UInt64:
         """


### PR DESCRIPTION
The bluechi-controller is currently a single point of failure. In order to address this issue and increase the resilience of the system, bluechi-agent should provide an API method to set the ControllerAddress= which triggers a disconnect in the agent and emits a signal that the address has been changed.